### PR TITLE
New package name and reaction refactored to autorun

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'space:reaction',
+  name: 'space:tracker-mobx-autorun',
   version: '0.1.0',
   summary: '',
   git: 'https://github.com/meteor-space/reaction.git',
@@ -10,5 +10,5 @@ Package.onUse(function(api) {
   api.versionsFrom('1.3');
   api.use('ecmascript');
   api.use('tmeasday:check-npm-versions');
-  api.mainModule('reaction.js', 'client');
+  api.mainModule('tracker-mobx-autorun.js', 'client');
 });

--- a/tracker-mobx-autorun.js
+++ b/tracker-mobx-autorun.js
@@ -3,11 +3,11 @@ import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
 
 checkNpmVersions({
   'mobx': '2.3.x'
-}, 'space:reaction');
+}, 'space:tracker-mobx-autorun');
 
 const { autorun } = require('mobx');
 
-export default (reaction) => {
+export default (trackerMobxAutorun) => {
   let mobxDisposer = null;
   let computation = null;
   let hasBeenStarted;
@@ -21,7 +21,7 @@ export default (reaction) => {
         }
         mobxDisposer = autorun(() => {
           if (isFirstRun) {
-            reaction();
+            trackerMobxAutorun();
           } else {
             computation.invalidate();
           }


### PR DESCRIPTION
Changes:
- package renamed to tracker-mobx-autorun
- function argument renamed from `reaction` to `trackerMobxAutorun`
