### PR TITLE
Live query support

### DIFF
--- a/autorun.js
+++ b/autorun.js
@@ -5,7 +5,6 @@ export default (trackerMobxAutorun) => {
   let mobxDisposer = null;
   let computation = null;
   let hasBeenStarted;
-  let subscriptionHandle;
   return {
     start() {
       let isFirstRun = true;
@@ -16,10 +15,9 @@ export default (trackerMobxAutorun) => {
         }
         mobxDisposer = autorun(() => {
           if (isFirstRun) {
-            subscriptionHandle = trackerMobxAutorun();
+            trackerMobxAutorun();
           } else {
             computation.invalidate();
-            subscriptionHandle && subscriptionHandle.stop();
           }
           isFirstRun = false;
         });
@@ -30,7 +28,6 @@ export default (trackerMobxAutorun) => {
       if (hasBeenStarted) {
         computation.stop();
         mobxDisposer();
-        subscriptionHandle && subscriptionHandle.stop();
       }
     }
   };

--- a/autorun.js
+++ b/autorun.js
@@ -1,0 +1,37 @@
+import { Tracker } from 'meteor/tracker';
+import { autorun } from 'mobx';
+
+export default (trackerMobxAutorun) => {
+  let mobxDisposer = null;
+  let computation = null;
+  let hasBeenStarted;
+  let subscriptionHandle;
+  return {
+    start() {
+      let isFirstRun = true;
+      computation = Tracker.autorun(() => {
+        if (mobxDisposer) {
+          mobxDisposer();
+          isFirstRun = true;
+        }
+        mobxDisposer = autorun(() => {
+          if (isFirstRun) {
+            subscriptionHandle = trackerMobxAutorun();
+          } else {
+            computation.invalidate();
+            subscriptionHandle && subscriptionHandle.stop();
+          }
+          isFirstRun = false;
+        });
+      });
+      hasBeenStarted = true;
+    },
+    stop() {
+      if (hasBeenStarted) {
+        computation.stop();
+        mobxDisposer();
+        subscriptionHandle && subscriptionHandle.stop();
+      }
+    }
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,40 +1,10 @@
-import { Tracker } from 'meteor/tracker';
 import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
+import observeCursor from './observe-cursor';
+import autorun from './autorun';
 
 checkNpmVersions({
   'mobx': '2.x'
 }, 'space:tracker-mobx-autorun');
 
-const { autorun } = require('mobx');
-
-export default (trackerMobxAutorun) => {
-  let mobxDisposer = null;
-  let computation = null;
-  let hasBeenStarted;
-  return {
-    start() {
-      let isFirstRun = true;
-      computation = Tracker.autorun(() => {
-        if (mobxDisposer) {
-          mobxDisposer();
-          isFirstRun = true;
-        }
-        mobxDisposer = autorun(() => {
-          if (isFirstRun) {
-            trackerMobxAutorun();
-          } else {
-            computation.invalidate();
-          }
-          isFirstRun = false;
-        });
-      });
-      hasBeenStarted = true;
-    },
-    stop() {
-      if (hasBeenStarted) {
-        computation.stop();
-        mobxDisposer();
-      }
-    }
-  };
-};
+export default autorun;
+export const observe = observeCursor;

--- a/observe-cursor.js
+++ b/observe-cursor.js
@@ -1,0 +1,38 @@
+import { Tracker } from 'meteor/tracker';
+import { action } from 'mobx';
+
+export default (actionPrefix = '', storeAttribute, handle, cursor) => {
+
+  if (handle.ready()) {
+    // initial fetch...
+    Tracker.nonreactive(() => {
+      action(`${actionPrefix}: initial fetch`, (comments) => {
+        storeAttribute.replace(comments);
+      })(cursor.fetch());
+    });
+
+    // ...and then observe
+    cursor.observe({
+      // we don't want that the addedAt function is triggered x times at the beginning
+      // just fetch them once (see above)
+      _suppress_initial: true,
+      addedAt: action(`${actionPrefix}: document added`, (document, atIndex) => {
+        storeAttribute.splice(atIndex, 0, document);
+      }),
+      changedAt: action(`${actionPrefix}: document changed`, (newDocument, oldDocument, atIndex) => {
+        storeAttribute.splice(atIndex, 1, newDocument);
+      }),
+      removedAt: action(`${actionPrefix}: document removed`, (oldDocument, atIndex) => {
+        storeAttribute.splice(atIndex, 1);
+      }),
+      movedTo: action(`${actionPrefix}: document moved`, (document, fromIndex, toIndex) => {
+        storeAttribute.splice(fromIndex, 1);
+        storeAttribute.splice(toIndex, 0, document);
+      }),
+    });
+  } else {
+    action(`${actionPrefix}: initialized`, () => {
+      storeAttribute.replace([]);
+    })();
+  }
+};

--- a/observe-cursor.js
+++ b/observe-cursor.js
@@ -1,13 +1,13 @@
 import { Tracker } from 'meteor/tracker';
 import { action } from 'mobx';
 
-export default (actionPrefix = '', storeAttribute, handle, cursor) => {
+export default (actionPrefix = '', observableArray, handle, cursor) => {
 
   if (handle.ready()) {
     // initial fetch...
     Tracker.nonreactive(() => {
       action(`${actionPrefix}: initial fetch`, (comments) => {
-        storeAttribute.replace(comments);
+        observableArray.replace(comments);
       })(cursor.fetch());
     });
 
@@ -17,22 +17,22 @@ export default (actionPrefix = '', storeAttribute, handle, cursor) => {
       // just fetch them once (see above)
       _suppress_initial: true,
       addedAt: action(`${actionPrefix}: document added`, (document, atIndex) => {
-        storeAttribute.splice(atIndex, 0, document);
+        observableArray.splice(atIndex, 0, document);
       }),
       changedAt: action(`${actionPrefix}: document changed`, (newDocument, oldDocument, atIndex) => {
-        storeAttribute.splice(atIndex, 1, newDocument);
+        observableArray.splice(atIndex, 1, newDocument);
       }),
       removedAt: action(`${actionPrefix}: document removed`, (oldDocument, atIndex) => {
-        storeAttribute.splice(atIndex, 1);
+        observableArray.splice(atIndex, 1);
       }),
       movedTo: action(`${actionPrefix}: document moved`, (document, fromIndex, toIndex) => {
-        storeAttribute.splice(fromIndex, 1);
-        storeAttribute.splice(toIndex, 0, document);
+        observableArray.splice(fromIndex, 1);
+        observableArray.splice(toIndex, 0, document);
       }),
     });
   } else {
     action(`${actionPrefix}: initialized`, () => {
-      storeAttribute.replace([]);
+      observableArray.clear();
     })();
   }
 };

--- a/observe-cursor.js
+++ b/observe-cursor.js
@@ -4,17 +4,16 @@ import { action } from 'mobx';
 export default (actionPrefix = '', observableArray, handle, cursor) => {
 
   if (handle.ready()) {
-    // initial fetch...
+    // initially fetch all documents and store them in the observable array
     Tracker.nonreactive(() => {
       action(`${actionPrefix}: initial fetch`, (comments) => {
         observableArray.replace(comments);
       })(cursor.fetch());
     });
 
-    // ...and then observe
+    // observe changes after initial fetch
     cursor.observe({
-      // we don't want that the addedAt function is triggered x times at the beginning
-      // just fetch them once (see above)
+      // _suppress_initial suppresses addedAt callback for documents initially fetched
       _suppress_initial: true,
       addedAt: action(`${actionPrefix}: document added`, (document, atIndex) => {
         observableArray.splice(atIndex, 0, document);


### PR DESCRIPTION
Autoruns are not very performant with large number of fetched documents (1000+) since whole observable array needs to be replaced by mobx. Cursor needs to be observed instead and only added, chaged, moved and removed documents updated in the observable array.

Here are findings from @RSchwan:
https://github.com/darko-mijic/mantra-sample-blog-app/pull/1#issuecomment-237278030

@RSchwan also proposed a solution here:
https://github.com/darko-mijic/mantra-sample-blog-app/pull/1#issuecomment-237333438

There is new `observe` export from the package which enables simplification of autoruns like in the example here:
https://github.com/darko-mijic/mantra-sample-blog-app/blob/28c236bb754467713eb4ffa3af067784cb0a012e/client/autoruns/comments.js

Thanks @RSchwan!
